### PR TITLE
EventPay Manager開発に必要なgemを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 - **Components**: ViewComponent
 - **Mail**: SendGrid
 - **Development**: Docker Compose
-- **GitHub CLI**: gh コマンド（PR作成・管理用）
+- **GitHub CLI**: gh コマンド（PR作成・管理、Issue作成・テンプレート利用）
 
 ## 認証システム
 - **幹事**: Rails 8標準認証（メール+パスワード）

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "jbuilder"
 
 # UI・コンポーネント系
 gem "view_component"
-gem "jquery-rails" 
+gem "jquery-rails"
 gem "bootstrap-icons-helper"
 
 # 日本語化
@@ -69,7 +69,7 @@ group :development, :test do
 
   # テスト環境
   gem "rspec-rails"
-  gem "factory_bot_rails" 
+  gem "factory_bot_rails"
   gem "faker"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,23 @@ gem "cssbundling-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
+# UI・コンポーネント系
+gem "view_component"
+gem "jquery-rails" 
+gem "bootstrap-icons-helper"
+
+# 日本語化
+gem "rails-i18n"
+gem "enum_help"
+
+# メール・外部サービス
+gem "sendgrid-ruby"
+
+# QRコード生成
+gem "rqrcode"
+
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
@@ -51,6 +66,11 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
+
+  # テスト環境
+  gem "rspec-rails"
+  gem "factory_bot_rails" 
+  gem "faker"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,12 +76,18 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
+    bootstrap-icons (1.0.15)
+      nokogiri (~> 1)
+    bootstrap-icons-helper (2.0.3)
+      bootstrap-icons (~> 1)
+      rails (>= 7.1)
     brakeman (7.1.0)
       racc
     builder (3.3.0)
@@ -94,6 +100,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chunky_png (1.4.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -103,13 +110,23 @@ GEM
     debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    diff-lcs (1.6.2)
     dotenv (3.1.8)
     drb (2.2.3)
     ed25519 (1.4.0)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erb (5.0.2)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
+    factory_bot (6.5.4)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.5.0)
+      factory_bot (~> 6.5)
+      railties (>= 6.1.0)
+    faker (3.5.2)
+      i18n (>= 1.8.11, < 2)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -129,6 +146,10 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.6.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     json (2.13.2)
     kamal (2.7.0)
       activesupport (>= 7.0)
@@ -225,6 +246,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.0.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.0.2)
       actionpack (= 8.0.2)
       activesupport (= 8.0.2)
@@ -242,6 +266,27 @@ GEM
     reline (0.6.2)
       io-console (~> 0.5)
     rexml (3.4.1)
+    rqrcode (3.1.0)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 2.0)
+    rqrcode_core (2.0.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-rails (8.0.1)
+      actionpack (>= 7.2)
+      activesupport (>= 7.2)
+      railties (>= 7.2)
+      rspec-core (~> 3.13)
+      rspec-expectations (~> 3.13)
+      rspec-mocks (~> 3.13)
+      rspec-support (~> 3.13)
+    rspec-support (3.13.4)
     rubocop (1.79.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -272,6 +317,7 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby_http_client (3.5.5)
     rubyzip (2.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.34.0)
@@ -280,6 +326,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sendgrid-ruby (6.7.0)
+      ruby_http_client (~> 3.4)
     solid_cable (3.0.11)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -320,6 +368,9 @@ GEM
     unicode-emoji (4.0.4)
     uri (1.0.3)
     useragent (0.16.11)
+    view_component (4.0.0)
+      activesupport (>= 7.1.0, < 8.1)
+      concurrent-ruby (~> 1)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -338,20 +389,30 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
+  bootstrap-icons-helper
   brakeman
   capybara
   cssbundling-rails
   debug
+  enum_help
+  factory_bot_rails
+  faker
   importmap-rails
   jbuilder
+  jquery-rails
   kamal
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)
+  rails-i18n
+  rqrcode
+  rspec-rails
   rubocop-rails-omakase
   selenium-webdriver
+  sendgrid-ruby
   solid_cable
   solid_cache
   solid_queue
@@ -359,6 +420,7 @@ DEPENDENCIES
   thruster
   turbo-rails
   tzinfo-data
+  view_component
   web-console
 
 BUNDLED WITH


### PR DESCRIPTION
## 概要
EventPay Manager本格開発に向けて、CLAUDE.mdの仕様に基づき必要なgemを追加しました。

## 追加されたgem

### 認証システム
- `bcrypt` - Rails 8標準認証に必要（コメントアウト解除）

### UI・コンポーネント系
- `view_component` - ViewComponent管理
- `jquery-rails` - jQuery統合
- `bootstrap-icons-helper` - Bootstrapアイコンヘルパー

### 日本語化
- `rails-i18n` - Rails日本語化
- `enum_help` - enum日本語化

### 外部サービス連携
- `sendgrid-ruby` - SendGridメール送信
- `rqrcode` - QRコード生成

### テスト環境
- `rspec-rails` - RSpecテストフレームワーク
- `factory_bot_rails` - テストデータファクトリ
- `faker` - ダミーデータ生成

## 確認事項
- ✅ bundle install 実行済み
- ✅ 全gem正常インストール確認済み
- ✅ Docker環境での動作確認済み

## テスト計画
bundle installの実行確認とgem一覧での存在確認を完了済みです。

🤖 Generated with [Claude Code](https://claude.ai/code)