### PR TITLE
feat: セッション開始時の自動mainブランチ更新機能を実装

### DIFF
--- a/docs/development/quick-reference.md
+++ b/docs/development/quick-reference.md
@@ -4,6 +4,18 @@
 
 ## 🚀 作業開始・完了コマンド
 
+### セッション開始
+```bash
+# 新しいセッション開始（自動mainブランチ更新）
+npm run session:start
+
+# セッション初期化（シンプル版）
+npm run session:init
+
+# 手動でmainブランチ切り替え（post-checkout hook自動実行）
+git checkout main
+```
+
 ### 作業開始
 ```bash
 # Claude連携型スマートワークフロー（推奨）
@@ -75,6 +87,10 @@ npm run dev:branch  # 対話式
 
 # Git hooks設定
 npm run hooks:install
+
+# セッション管理
+npm run session:start  # mainブランチ切り替え+最新化
+npm run session:init   # シンプルな初期化
 ```
 
 ### 品質チェック
@@ -277,4 +293,35 @@ npm run pr:create
 - 新しいコマンドを追加したらここにも記載
 - 不明点は`@claude`に質問
 
-🆙 **最新更新**: 2025-07-31 - Rails 8.0.2対応、npmスクリプト更新
+## 🔄 セッション管理機能
+
+### 自動mainブランチ更新
+新しいセッション開始時に自動でmainブランチを最新化する機能が実装されています。
+
+#### Git Post-Checkout Hook
+- mainブランチに切り替える際、自動的に最新のコミットをチェック
+- リモートに新しいコミットがある場合、安全に自動更新実行
+- 未コミット変更がある場合は警告表示
+
+#### セッション開始コマンド
+```bash
+# 推奨: 完全なセッション開始
+npm run session:start
+
+# シンプル: 基本的な初期化のみ
+npm run session:init
+
+# 手動: Git hook自動実行
+git checkout main
+```
+
+#### 動作フロー
+1. `git checkout main` 実行
+2. post-checkout hook が自動起動
+3. リモートから最新情報をフェッチ
+4. ローカルとリモートの差分をチェック
+5. 安全に自動更新または警告表示
+
+---
+
+🆙 **最新更新**: 2025-08-01 - セッション自動更新機能追加、Rails 8.0.2対応

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "quality:check": "docker-compose exec web bundle exec rubocop && docker-compose exec web bundle exec rspec",
     "security:scan": "docker-compose exec web bundle exec brakeman --no-pager",
     "work:start:cli": "node scripts/work-start-cli.js",
-    "dev:branch:cli": "node scripts/create-branch-cli.js"
+    "dev:branch:cli": "node scripts/create-branch-cli.js",
+    "session:start": "git checkout main && npm run git:update && echo '🚀 新しいセッション開始準備完了'",
+    "session:init": "git checkout main && git pull origin main && echo '✅ セッション初期化完了 - 最新のmainブランチから開始できます'"
   }
 }


### PR DESCRIPTION
## 🎯 概要
新しいセッション開始時に自動でmainブランチを最新化する機能を実装しました。これにより、開発者は常に最新のmainブランチから作業を開始できます。

## 🚀 実装内容

### 1. Git Post-Checkout Hook
**ファイル**: `.git/hooks/post-checkout`
- mainブランチ切り替え時の自動処理
- リモートとの差分チェック
- 安全な自動更新（未コミット変更の検出）
- 情報表示とガイダンス提供

### 2. NPMセッション管理スクリプト
**ファイル**: `package.json`
```json
{
  "session:start": "git checkout main && npm run git:update && echo '🚀 新しいセッション開始準備完了'",
  "session:init": "git checkout main && git pull origin main && echo '✅ セッション初期化完了 - 最新のmainブランチから開始できます'"
}
```

### 3. ドキュメント更新
**ファイル**: `docs/development/quick-reference.md`
- セッション管理機能の詳細説明
- 使用方法と動作フローの追加
- コマンド例の充実

## 🔧 機能詳細

### Git Post-Checkout Hook動作フロー
1. `git checkout main` 実行
2. post-checkout hook自動起動
3. リモートから最新情報をフェッチ
4. ローカルとリモートの差分をチェック
5. 安全に自動更新または警告表示

### セッション開始コマンド
```bash
# 推奨: 完全なセッション開始
npm run session:start

# シンプル: 基本的な初期化のみ  
npm run session:init

# 手動: Git hook自動実行
git checkout main
```

## ✅ 安全性機能
- **未コミット変更検出**: 作業中の変更がある場合は自動更新を停止し、手動操作を促すメッセージを表示
- **リモート差分チェック**: フェッチしてから差分を確認し、必要な場合のみ更新実行
- **エラーハンドリング**: pull失敗時の適切なエラーメッセージ表示

## 🎉 効果・メリット
- **開発効率向上**: セッション開始時の手動操作を自動化
- **ミス防止**: 古いmainブランチからの作業開始を防止
- **一貫性確保**: 全開発者が同じ最新状態から作業開始
- **情報提供**: 取得したコミット数や次のステップを明確に表示

## 🧪 テスト結果
- [x] Git post-checkout hook正常動作確認
- [x] npm session:start コマンド動作確認
- [x] npm session:init コマンド動作確認
- [x] mainブランチ自動更新機能確認
- [x] 未コミット変更時の安全性確認
- [x] ブランチ切り替え時の適切なメッセージ表示

## 📋 今後の改善案
- セッション履歴の記録機能
- 複数リモートブランチ対応
- 設定ファイルによるカスタマイズ機能

## 🔗 関連ドキュメント
- [クイックリファレンス](docs/development/quick-reference.md#セッション管理機能)
- [開発ルール](docs/setup/development-rules.md)
- [GitHubワークフロー](docs/workflows/github-workflow.md)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>